### PR TITLE
helpers: Get rid of lava-test-case

### DIFF
--- a/helpers/assert_driver_present
+++ b/helpers/assert_driver_present
@@ -14,4 +14,4 @@ else
 	TEST_RESULT="fail"
 fi
 
-lava-test-case "${TEST_CASE_ID}" --result ${TEST_RESULT}
+echo "${TEST_CASE_ID}: ${TEST_RESULT}"

--- a/helpers/assert_mmc_present
+++ b/helpers/assert_mmc_present
@@ -14,4 +14,4 @@ else
 	TEST_RESULT="fail"
 fi
 
-lava-test-case "${TEST_CASE_ID}" --result ${TEST_RESULT}
+echo "${TEST_CASE_ID}: ${TEST_RESULT}"

--- a/helpers/assert_partition_found
+++ b/helpers/assert_partition_found
@@ -14,4 +14,4 @@ else
 	TEST_RESULT="fail"
 fi
 
-lava-test-case "${TEST_CASE_ID}" --result ${TEST_RESULT}
+echo "${TEST_CASE_ID}: ${TEST_RESULT}"

--- a/helpers/bootrr
+++ b/helpers/bootrr
@@ -15,7 +15,7 @@ timeout() {
 
 test_report_exit() {
 	TEST_RESULT=$1
-	lava-test-case ${TEST_CASE_ID} --result ${TEST_RESULT}
+	echo "${TEST_CASE_ID}: ${TEST_RESULT}"
 	exit 0
 }
 

--- a/helpers/rproc-start
+++ b/helpers/rproc-start
@@ -6,7 +6,7 @@ DEVICE="$2"
 test_report_exit()
 {
 	TEST_RESULT=$1
-	lava-test-case ${TEST_CASE_ID} --result ${TEST_RESULT}
+	echo "${TEST_CASE_ID}: ${TEST_RESULT}"
 	exit 0
 }
 

--- a/helpers/rproc-stop
+++ b/helpers/rproc-stop
@@ -6,7 +6,7 @@ DEVICE="$2"
 test_report_exit()
 {
 	TEST_RESULT=$1
-	lava-test-case "${TEST_CASE_ID}" --result ${TEST_RESULT}
+	echo "${TEST_CASE_ID}: ${TEST_RESULT}"
 	exit 0
 }
 


### PR DESCRIPTION
Removes the dependency of lava-test-case be able run outside
LAVA environment.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>