### PR TITLE
Local

### DIFF
--- a/helpers/assert_device_present
+++ b/helpers/assert_device_present
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source /usr/bin/bootrr
+source bootrr
 
 TEST_CASE_ID="$1"
 DRIVER="$2"

--- a/helpers/assert_device_present
+++ b/helpers/assert_device_present
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source bootrr
+. bootrr
 
 TEST_CASE_ID="$1"
 DRIVER="$2"

--- a/helpers/assert_driver_present
+++ b/helpers/assert_driver_present
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source /usr/bin/bootrr
+source bootrr
 
 TEST_CASE_ID="$1"
 DRIVER="$2"

--- a/helpers/assert_driver_present
+++ b/helpers/assert_driver_present
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source bootrr
+. bootrr
 
 TEST_CASE_ID="$1"
 DRIVER="$2"

--- a/helpers/bootrr
+++ b/helpers/bootrr
@@ -15,7 +15,12 @@ timeout() {
 
 test_report_exit() {
 	TEST_RESULT=$1
-	lava-test-case ${TEST_CASE_ID} --result ${TEST_RESULT}
+	command -v lava-test-case
+	if [ "$?" -eq 0 ]; then
+		lava-test-case ${TEST_CASE_ID} --result ${TEST_RESULT}
+	else
+		echo "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=${TEST_CASE_ID} RESULT=${TEST_RESULT}>"
+	fi
 	exit 0
 }
 

--- a/helpers/ensure_lib_firmware
+++ b/helpers/ensure_lib_firmware
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source bootrr
+. bootrr
 
 TEST_CASE_ID="$1"
 PARTITION=/dev/disk/by-partlabel/userdata

--- a/helpers/ensure_lib_firmware
+++ b/helpers/ensure_lib_firmware
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source /usr/bin/bootrr
+source bootrr
 
 TEST_CASE_ID="$1"
 PARTITION=/dev/disk/by-partlabel/userdata


### PR DESCRIPTION
with these 2 patches, i can run with bootrr scripts installed in /usr/bin, with 
/usr/bin/arrow,apq8096-db820c

or I can also directly run them without installing them, directly from the git tree, using:

export PATH=$PWD/helpers:$PATH
./boards/arrow,apq8096-db820c 

which is really convenient

It's also convenient to not have to worry about lava-test-case.. 