### PR TITLE
Makefile: fixes board name for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ HELPERS := assert_device_present \
 	   state_check
 
 BOARDS := arrow,apq8096-db820c \
-	  google,kevin \
+	  google,rk3399-kevin \
 	  qcom,apq8016-sbc \
 	  qcom,msm8998-mtp \
 	  qcom,sdm845-mtp \


### PR DESCRIPTION
Fixes c5d93c41f893 (boards: Add Samsung Chromebook Plus test script),
which wouldn't compile.

make: *** No rule to make target 'boards/google,kevin', needed by '/tmp/bin/google,kevin'.  Stop.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>