### PR TITLE
Add support for Peach-Pi and Veyron Jaq Chromebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ HELPERS := assert_device_present \
 BOARDS := arrow,apq8096-db820c \
 	  google,kevin \
 	  google,pi \
+	  google,veyron-jaq \
 	  qcom,apq8016-sbc \
 	  qcom,msm8998-mtp \
 	  qcom,sdm845-mtp \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ HELPERS := assert_device_present \
 
 BOARDS := arrow,apq8096-db820c \
 	  google,kevin \
+	  google,pi \
 	  qcom,apq8016-sbc \
 	  qcom,msm8998-mtp \
 	  qcom,sdm845-mtp \

--- a/boards/google,pi
+++ b/boards/google,pi
@@ -1,0 +1,178 @@
+#!/bin/sh
+
+assert_driver_present cros-ec-i2c-tunnel-driver-present cros-ec-i2c-tunnel
+assert_device_present cros-ec-i2c-tunnel-probed cros-ec-i2c-tunnel 12d40000.*
+
+assert_driver_present cros-ec-keyb-driver-present cros-ec-keyb
+assert_device_present cros-ec-keyb-probed cros-ec-keyb 12d40000.*
+
+assert_driver_present dwc3-driver-present dwc3
+assert_device_present dwc3-usbdrd3_0-probed dwc3 12000000.*
+assert_device_present dwc3-usbdrd3_1-probed dwc3 12400000.*
+
+assert_driver_present dwmmc_exynos-driver-present dwmmc_exynos
+assert_device_present dwmmc_exynos-mmc_0-probed dwmmc_exynos 12200000.*
+assert_device_present dwmmc_exynos-mmc_1-probed dwmmc_exynos 12210000.*
+assert_device_present dwmmc_exynos-mmc_2-probed dwmmc_exynos 12220000.*
+
+assert_driver_present exynos-adc-driver-present exynos-adc
+assert_device_present exynos-adc-probed exynos-adc 12d10000.*
+
+assert_driver_present exynos-audss-clk-driver-present exynos-audss-clk
+assert_device_present exynos-audss-clk-clock_audss-probed exynos-audss-clk 3810000.*
+
+assert_driver_present exynos-dp-driver-present exynos-dp
+assert_device_present exynos-dp-probed exynos-dp 145b0000.*
+
+assert_driver_present exynos-dp-video-phy-driver-present exynos-dp-video-phy
+assert_device_present exynos-dp-video-phy-probed exynos-dp-video-phy soc:dp-video-phy
+
+assert_driver_present exynos-drm-driver-present exynos-drm
+assert_device_present exynos-drm-probed exynos-drm exynos-drm
+
+assert_driver_present exynos-dwc3-driver-present exynos-dwc3
+assert_device_present exynos-dwc3-0-probed exynos-dwc3 soc:usb3-0
+assert_device_present exynos-dwc3-1-probed exynos-dwc3 soc:usb3-1
+
+assert_driver_present exynos-ehci-driver-present exynos-ehci
+assert_device_present exynos-ehci-usbdrd_phy0-probed exynos-ehci 12110000.*
+
+assert_driver_present exynos-gsc-driver-present exynos-gsc
+assert_device_present exynos-gsc_0-probed exynos-gsc 13e00000.*
+assert_device_present exynos-gsc_1-probed exynos-gsc 13e10000.*
+
+assert_driver_present exynos-hdmi-driver-present exynos-hdmi
+assert_device_present exynos-hdmi-probed exynos-hdmi 14530000.*
+
+assert_driver_present exynos-mipi-video-phy-driver-present exynos-mipi-video-phy
+assert_device_present exynos-mipi-video-phy-probed exynos-mipi-video-phy soc:mipi-video-phy
+
+assert_driver_present exynos-mixer-driver-present exynos-mixer
+assert_device_present exynos-mixer-probed exynos-mixer 14450000.*
+
+assert_driver_present exynos-ohci-driver-present exynos-ohci
+assert_device_present exynos-ohci-usbhost1-probed exynos-ohci 12120000.*
+
+assert_driver_present exynos-pmu-driver-present exynos-pmu
+assert_device_present exynos-pmu-system_controller-probed exynos-pmu 10040000.*
+
+assert_driver_present exynos-rng-driver-present exynos-rng
+assert_device_present exynos-rng-prng-probed exynos-rng 10830400.*
+
+assert_driver_present exynos-srom-driver-present exynos-srom
+assert_device_present exynos-srom-probed exynos-srom 12250000.*
+
+assert_driver_present exynos-tmu-driver-present exynos-tmu
+assert_device_present exynos-tmu-cpu0-probed exynos-tmu 10060000.*
+assert_device_present exynos-tmu-cpu1-probed exynos-tmu 10068000.*
+assert_device_present exynos-tmu-cpu2-probed exynos-tmu 100a0000.*
+assert_device_present exynos-tmu-cpu3-probed exynos-tmu 10064000.*
+assert_device_present exynos-tmu-cpu4-probed exynos-tmu 1006c000.*
+
+assert_driver_present exynos-trng-driver-present exynos-trng
+assert_device_present exynos-trng-probed exynos-trng 10830600.*
+
+assert_driver_present exynos4-fb-driver-present exynos4-fb
+assert_device_present exynos4-fb-fimd-probed exynos4-fb 14400000.*
+
+assert_driver_present exynos5-clock-driver-present exynos5-clock
+assert_device_present exynos5-clock-probed exynos5-clock 10010000.*
+
+assert_driver_present exynos5-hsi2c-driver-present exynos5-hsi2c
+assert_device_present exynos5-hsi2c_4-probed exynos5-hsi2c 12ca0000.*
+assert_device_present exynos5-hsi2c_5-probed exynos5-hsi2c 12cd0000.*
+assert_device_present exynos5-hsi2c_6-probed exynos5-hsi2c 12e00000.*
+assert_device_present exynos5-hsi2c_7-probed exynos5-hsi2c 12e10000.*
+
+assert_driver_present exynos5-subcmu-driver-present exynos5-subcmu
+assert_device_present exynos5-subcmu-DISP-probed exynos5-subcmu DISP
+assert_device_present exynos5-subcmu-GSC-probed exynos5-subcmu GSC
+assert_device_present exynos5-subcmu-MFC-probed exynos5-subcmu MFC
+
+assert_driver_present exynos5_usb3drd_phy-driver-present exynos5_usb3drd_phy
+assert_device_present exynos5_usb3drd_usbdrd_phy0-probed exynos5_usb3drd_phy 12100000.*
+assert_device_present exynos5_usb3drd_usbdrd_phy1-probed exynos5_usb3drd_phy 12500000.*
+
+assert_driver_present hdmi-audio-codec-driver-present hdmi-audio-codec
+assert_device_present hdmi-audio-codec-probed hdmi-audio-codec hdmi-audio-codec.*
+
+assert_driver_present max77686-clk-driver-present max77686-clk
+assert_device_present max77686-clk-probed max77686-clk max77802-clk
+
+assert_driver_present max77686-rtc-driver-present max77686-rtc
+assert_device_present max77686-rtc-probed max77686-rtc max77802-rtc
+
+assert_driver_present max77802-pmic-driver-present max77802-pmic
+assert_device_present max77802-pmic-probed max77802-pmic max77802-pmic
+
+assert_driver_present ntc-thermistor-driver-present ntc-thermistor
+assert_device_present ntc-thermistor-3-probed ntc-thermistor 12d10000.adc:thermistor3
+assert_device_present ntc-thermistor-4-probed ntc-thermistor 12d10000.adc:thermistor4
+assert_device_present ntc-thermistor-5-probed ntc-thermistor 12d10000.adc:thermistor5
+assert_device_present ntc-thermistor-6-probed ntc-thermistor 12d10000.adc:thermistor6
+
+assert_driver_present pwm-backlight-driver-present pwm-backlight
+assert_device_present pwm-backlight-probed pwm-backlight backlight
+
+assert_driver_present reg-fixed-voltage-driver-present reg-fixed-voltage
+assert_device_present reg-fixed-voltage-probed reg-fixed-voltage fixed-regulator
+assert_device_present reg-usb300-probed reg-fixed-voltage regulator-usb300
+assert_device_present reg-usb301-probed reg-fixed-voltage regulator-usb301
+
+assert_driver_present s3c-i2c-driver-present s3c-i2c
+assert_device_present s3c-i2c_2-probed s3c-i2c 12c80000.*
+
+assert_driver_present s3c-rtc-driver-present s3c-rtc
+assert_device_present s3c-rtc-probed s3c-rtc 101e0000.*
+
+assert_driver_present s3c64xx-spi-driver-present s3c64xx-spi
+assert_device_present s3c64xx-spi_2-probed s3c64xx-spi 12d40000.*
+
+assert_driver_present s5p-jpeg-driver-present s5p-jpeg
+assert_device_present s5p-jpeg_0-probed s5p-jpeg 11f50000.*
+assert_device_present s5p-jpeg_1-probed s5p-jpeg 11f60000.*
+
+assert_driver_present s5p-mfc-driver-present s5p-mfc
+assert_device_present s5p-mfc-probed s5p-mfc 11000000.*
+
+assert_driver_present s5p-secss-driver-present s5p-secss
+assert_device_present s5p-secss-probed s5p-secss 10830000.*
+
+assert_driver_present samsung-i2s-driver-present samsung-i2s
+assert_device_present samsung-i2s0-probed samsung-i2s 3830000.*
+
+assert_driver_present samsung-pinctrl-driver-present samsung-pinctrl
+assert_device_present samsung-pinctrl_0-probed samsung-pinctrl 13400000.*
+assert_device_present samsung-pinctrl_1-probed samsung-pinctrl 13410000.*
+assert_device_present samsung-pinctrl_2-probed samsung-pinctrl 14000000.*
+assert_device_present samsung-pinctrl_3-probed samsung-pinctrl 14010000.*
+assert_device_present samsung-pinctrl_4-probed samsung-pinctrl 3860000.*
+
+assert_driver_present samsung-pwm-driver-present samsung-pwm
+assert_device_present samsung-pwm-probed samsung-pwm 12dd0000.*
+
+assert_driver_present samsung-uart-driver-present samsung-uart
+assert_device_present samsung-uart_serial_0-probed samsung-uart 12c00000.*
+assert_device_present samsung-uart-serial_1-probed samsung-uart 12c10000.*
+assert_device_present samsung-uart-serial_2-probed samsung-uart 12c20000.*
+assert_device_present samsung-uart-serial_3-probed samsung-uart 12c30000.*
+
+assert_driver_present samsung-usb2-phy-driver-present samsung-usb2-phy
+assert_device_present samsung-usb2-phy-probed samsung-usb2-phy 12130000.phy
+
+assert_driver_present syscon-poweroff-driver-present syscon-poweroff
+assert_device_present syscon-poweroff-probed syscon-poweroff 10040000.*
+
+assert_driver_present syscon-reboot-driver-present syscon-reboot
+assert_device_present syscon-reboot-probed syscon-reboot 10040000.*
+
+assert_driver_present tps65090-charger-driver-present tps65090-charger
+assert_device_present tps65090-charger-probed tps65090-charger tps65090-charger
+
+assert_driver_present tps65090-pmic-driver-present tps65090-pmic
+assert_device_present tps65090-pmic-probed tps65090-pmic tps65090-pmic
+
+assert_driver_present xhci-hcd-driver-present xhci-hcd
+assert_device_present xhci-hcd_0-probed xhci-hcd xhci-hcd.0.*
+assert_device_present xhci-hcd_1-probed xhci-hcd xhci-hcd.1.*
+

--- a/boards/google,veyron-jaq
+++ b/boards/google,veyron-jaq
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+# assert_driver_present cros-ec-debugfs-driver-present cros-ec-debugfs
+# assert_device_present cros-ec-debugfs-probed cros-ec-debugfs cros-ec-debugfs.*
+# assert_sysfs_attr_present cros-ec-debugfs-attr-ec /sys/kernel/debug/cros_ec
+
+# assert_driver_present cros-ec-dev-driver-present cros-ec-dev
+# assert_device_present cros-ec-dev-probed cros-ec-dev cros-ec-dev.*
+
+assert_driver_present cros-ec-i2c-tunnel-driver-present cros-ec-i2c-tunnel
+assert_device_present cros-ec-i2c-tunnel-probed cros-ec-i2c-tunnel ff110000.*
+
+assert_driver_present cros-ec-keyb-driver-present cros-ec-keyb
+assert_device_present cros-ec-keyb-probed cros-ec-keyb ff110000.*
+
+# assert_driver_present cros-ec-lightbar-driver-present cros-ec-lightbar
+# assert_device_present cros-ec-lightbar-driver-present is expected to fail.
+
+assert_driver_present dw-apb-uart-driver-present dw-apb-uart
+assert_device_present dw-apb-uart0-probed dw-apb-uart ff180000.*
+assert_device_present dw-apb-uart1-probed dw-apb-uart ff190000.*
+assert_device_present dw-apb-uart2-probed dw-apb-uart ff690000.*
+
+assert_driver_present dw_wdt-driver-present dw_wdt
+assert_device_present dw_wdt-probed dw_wdt ff800000.*
+
+assert_driver_present dwc2-driver-present dwc2
+assert_device_present dwc2-usb_host1-probed dwc2 ff540000.*
+assert_device_present dwc2-usb_otg-probed dwc2 ff580000.*
+
+assert_driver_present dwhdmi-rockchip-driver-present dwhdmi-rockchip
+assert_device_present dwhdmi-rockchip-probed dwhdmi-rockchip ff980000.*
+
+assert_driver_present dwmmc_rockchip-driver-present dwmmc_rockchip
+assert_device_present dwmmc_rockchip-sdmmc-probed dwmmc_rockchip ff0c0000.*
+assert_device_present dwmmc_rockchip-sdio0-probed dwmmc_rockchip ff0d0000.*
+assert_device_present dwmmc_rockchip-emmc-probed dwmmc_rockchip ff0f0000.*
+
+assert_driver_present ehci-platform-driver-present ehci-platform
+assert_device_present ehci-platform-usb_host0_ehci-probed ehci-platform ff500000.*
+
+assert_driver_present ramoops-driver-present ramoops
+assert_device_present ramoops-probed ramoops 7fedc000.*
+
+assert_driver_present rk3288-crypto-driver-present rk3288-crypto
+assert_device_present rk3288-crypto-probed rk3288-crypto ff8a0000.*
+
+assert_driver_present rk3x-i2c-driver-present rk3x-i2c
+assert_device_present rk3x-i2c0-probed rk3x-i2c ff650000.*
+assert_device_present rk3x-i2c1-probed rk3x-i2c ff140000.*
+assert_device_present rk3x-i2c2-probed rk3x-i2c ff660000.*
+assert_device_present rk3x-i2c4-probed rk3x-i2c ff160000.*
+assert_device_present rk3x-i2c5-probed rk3x-i2c ff170000.*
+
+assert_driver_present rk_iommu-driver-present rk_iommu
+assert_device_present rk_iommu-vopb_mmu-probed rk_iommu ff930300.*
+assert_device_present rk_iommu-vopl_mmu-probed rk_iommu ff940300.*
+assert_device_present rk_iommu-vpu_mmu-probed rk_iommu ff9a0800.*
+
+assert_driver_present rockchip-dp-driver-present rockchip-dp
+assert_device_present rockchip-dp-edp-probed rockchip-dp ff970000.*
+
+assert_driver_present rockchip-dp-phy-driver-present rockchip-dp-phy
+assert_device_present rockchip-dp-phy-grf-probed rockchip-dp-phy ff770000.*
+
+assert_driver_present rockcip-i2s-driver-present rockchip-i2s
+assert_device_present rockchip-i2s-probed rockchip-i2s ff890000.*
+
+assert_driver_present rockchip-iodomain-driver-present rockchip-iodomain
+assert_device_present rockchip-iodomain-grf-probed rockchip-iodomain ff770000.*
+
+assert_driver_present rockchip-pm-domain-driver-present rockchip-pm-domain
+assert_device_present rockchip-pm-domain-pmu-probed rockchip-pm-domain ff730000.*
+
+assert_driver_present rockchip-pwm-driver-present rockchip-pwm
+assert_device_present rockchip-pwm0-probed rockchip-pwm ff680000.*
+assert_device_present rockchip-pwm1-probed rockchip-pwm ff680010.*
+
+assert_driver_present rockchip-spi-driver-present rockchip-spi
+assert_device_present rockchip-spi0-probed rockchip-spi ff110000.*
+assert_device_present rockchip-spi2-probed rockchip-spi ff130000.*
+
+assert_driver_present rockchip-thermal-driver-present rockchip-thermal
+assert_device_present rockchip-thermal-tsadc-probed rockchip-thermal ff280000.*
+
+assert_driver_present rockchip-usb-phy-driver-present rockchip-usb-phy
+assert_device_present rockchip-usb-phy-grf-probed rockchip-usb-phy ff770000.*
+
+assert_driver_present rockchip-vop-driver-present rockchip-vop
+assert_device_present rockchip-vopb-probed rockchip-vop ff930000.*
+assert_device_present rockchip-vopl-probed rockchip-vop ff940000.*
+
+assert_driver_present sram-driver-present sram
+assert_device_present sram-probed sram ff720000.*
+


### PR DESCRIPTION
So this is the second version of the pull request #14

Changes since #14:
- Use the DT compatible string as a name for the test script.
- Add the boards to the Makefile.
- Removed the patch that added the Chromebooks test runner (should be more generic and not really needed with current infrastructure)
