### PR TITLE
Add scripts to perform generic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ HELPERS := assert_device_present \
 	   assert_partition_found \
 	   assert_sysfs_attr_present \
 	   bootrr \
+	   bootrr-auto \
 	   ensure_lib_firmware \
 	   rproc-start \
 	   rproc-stop \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ all:
 
 all-install :=
 
-HELPERS := assert_device_present \
+HELPERS := assert_file_is_empty \
+           assert_device_present \
            assert_driver_present \
 	   assert_mmc_present \
 	   assert_partition_found \

--- a/helpers/assert_file_is_empty
+++ b/helpers/assert_file_is_empty
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+FILEPATH="$2"
+TIMEOUT="${4:-1}"
+
+if [ -z "${TEST_CASE_ID}" -o -z "${FILEPATH}" ]; then
+	echo "Usage: $0 <test-case-id> <file path> [<timeout>]"
+	exit 1
+fi
+
+if [ ! -e "${FILEPATH}" ]
+then
+	test_report_exit skip
+fi
+
+timeout ${TIMEOUT} [ -s "${FILEPATH}" ] || test_report_exit pass
+
+test_report_exit fail

--- a/helpers/bootrr-auto
+++ b/helpers/bootrr-auto
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+$(pwd)/helpers/bootrr-generic-tests
+
 for TEST in $(tr "\0" "\n" < /proc/device-tree/compatible); do
 	if [ -x "/usr/bin/${TEST}" ]; then
 		/usr/bin/${TEST}

--- a/helpers/bootrr-auto
+++ b/helpers/bootrr-auto
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for TEST in $(tr "\0" "\n" < /proc/device-tree/compatible); do
+	if [ -x "/usr/bin/${TEST}" ]; then
+		/usr/bin/${TEST}
+	elif [ -x "$(pwd)/boards/${TEST}" ]; then
+		$(pwd)/boards/${TEST}
+	fi
+done

--- a/helpers/bootrr-generic-tests
+++ b/helpers/bootrr-generic-tests
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+assert_file_is_empty deferred-probe-empty /sys/kernel/debug/devices_deferred
+


### PR DESCRIPTION
Currently tests are related to boards but some of them are generic and can be developed in a common script.