### PR TITLE
T14637 fix install directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ BOARDS := arrow,apq8096-db820c \
 	  sony,xperia-castor
 
 define add-scripts
-$(DESTDIR)$(prefix)/bin/$2: $1/$2
+$(DESTDIR)$(prefix)/$1/$2: $1/$2
 	@echo "INSTALL $$<"
 	@install -D -m 755 $$< $$@
 
-all-install += $(DESTDIR)$(prefix)/bin/$2
+all-install += $(DESTDIR)$(prefix)/$1/$2
 endef
 
 $(foreach v,${BOARDS},$(eval $(call add-scripts,boards,$v)))

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ HELPERS := assert_file_is_empty \
 	   assert_sysfs_attr_present \
 	   bootrr \
 	   bootrr-auto \
+	   bootrr-generic-tests \
 	   ensure_lib_firmware \
 	   rproc-start \
 	   rproc-stop \

--- a/helpers/bootrr-auto
+++ b/helpers/bootrr-auto
@@ -3,9 +3,7 @@
 $(pwd)/helpers/bootrr-generic-tests
 
 for TEST in $(tr "\0" "\n" < /proc/device-tree/compatible); do
-	if [ -x "/usr/bin/${TEST}" ]; then
-		/usr/bin/${TEST}
-	elif [ -x "$(pwd)/boards/${TEST}" ]; then
+	if [ -x "$(pwd)/boards/${TEST}" ]; then
 		$(pwd)/boards/${TEST}
 	fi
 done


### PR DESCRIPTION
This is to always keep the `boards` and `helpers` directories when installing `bootrr`, to make `bootrr-auto` work in the same way regardless of where it's installed.