### PR TITLE
Fix i2c5 test on veyron and extend veyron and kevin with codec audio tests

### DIFF
--- a/boards/google,kevin
+++ b/boards/google,kevin
@@ -34,7 +34,14 @@ assert_sysfs_attr_present cros-ec-sysfs-attr-flashinfo /sys/class/chromeos/cros_
 assert_sysfs_attr_present cros-ec-sysfs-attr-kb_wake_angle /sys/class/chromeos/cros_ec/kb_wake_angle
 assert_sysfs_attr_present cros-ec-sysfs-attr-veresion /sys/class/chromeos/cros_ec/version
 
+assert_driver_present hdmi-audio-codec-driver-present hdmi-audio-codec
+assert_device_present hdmi-audio-codec-probed hdmi-audio-codec hdmi-audio-codec.*
+
 assert_driver_present rk3399-gru-sound-driver-present rk3399-gru-sound
+assert_driver_present rk3399-gru-sound-driver-da7219-present rk3399-gru-sound sound/DA7219
+assert_driver_present rk3399-gru-sound-driver-dp-present rk3399-gru-sound sound/DP
+assert_driver_present rk3399-gru-sound-driver-max98357A-present rk3399-gru-sound sound/MAX98357A
+assert_driver_present rk3399-gru-sound-driver-rt5514-present rk3399-gru-sound sound/RT5514
 
 assert_driver_present rk3x-i2c-driver-present rk3x-i2c
 assert_device_present rk3x-i2c0-probed rk3x-i2c ff3c0000.i2c

--- a/boards/google,veyron-jaq
+++ b/boards/google,veyron-jaq
@@ -4,8 +4,8 @@
 # assert_device_present cros-ec-debugfs-probed cros-ec-debugfs cros-ec-debugfs.*
 # assert_sysfs_attr_present cros-ec-debugfs-attr-ec /sys/kernel/debug/cros_ec
 
-# assert_driver_present cros-ec-dev-driver-present cros-ec-dev
-# assert_device_present cros-ec-dev-probed cros-ec-dev cros-ec-dev.*
+assert_driver_present cros-ec-dev-driver-present cros-ec-dev
+assert_device_present cros-ec-dev-probed cros-ec-dev cros-ec-dev.*
 
 assert_driver_present cros-ec-i2c-tunnel-driver-present cros-ec-i2c-tunnel
 assert_device_present cros-ec-i2c-tunnel-probed cros-ec-i2c-tunnel ff110000.*
@@ -30,6 +30,8 @@ assert_device_present dwc2-usb_otg-probed dwc2 ff580000.*
 
 assert_driver_present dwhdmi-rockchip-driver-present dwhdmi-rockchip
 assert_device_present dwhdmi-rockchip-probed dwhdmi-rockchip ff980000.*
+assert_driver_present dwhdmi-rockchip-driver-audio-present dwhdmi-rockchip ff980000.hdmi/dw-hdmi-audio-*
+assert_driver_present dwhdmi-rockchip-driver-cec-present dwhdmi-rockchip ff980000.hdmi/dw-hdmi-cec.*
 assert_driver_present dwhdmi-rockchip-driver-i2c-present dwhdmi-rockchip ff980000.hdmi/i2c-*
 
 assert_driver_present dwmmc_rockchip-driver-present dwmmc_rockchip

--- a/boards/google,veyron-jaq
+++ b/boards/google,veyron-jaq
@@ -30,6 +30,7 @@ assert_device_present dwc2-usb_otg-probed dwc2 ff580000.*
 
 assert_driver_present dwhdmi-rockchip-driver-present dwhdmi-rockchip
 assert_device_present dwhdmi-rockchip-probed dwhdmi-rockchip ff980000.*
+assert_driver_present dwhdmi-rockchip-driver-i2c-present dwhdmi-rockchip ff980000.hdmi/i2c-*
 
 assert_driver_present dwmmc_rockchip-driver-present dwmmc_rockchip
 assert_device_present dwmmc_rockchip-sdmmc-probed dwmmc_rockchip ff0c0000.*
@@ -50,7 +51,6 @@ assert_device_present rk3x-i2c0-probed rk3x-i2c ff650000.*
 assert_device_present rk3x-i2c1-probed rk3x-i2c ff140000.*
 assert_device_present rk3x-i2c2-probed rk3x-i2c ff660000.*
 assert_device_present rk3x-i2c4-probed rk3x-i2c ff160000.*
-assert_device_present rk3x-i2c5-probed rk3x-i2c ff170000.*
 
 assert_driver_present rk_iommu-driver-present rk_iommu
 assert_device_present rk_iommu-vopb_mmu-probed rk_iommu ff930300.*


### PR DESCRIPTION
The first commit solves an old issue regarding i2c5 test failing on veyron boards due a change in the kernel since 5.2.

The second and third commit extends the test coverage with audio codec tests for veyron and kevin.

Patches can be picked individually.