### PR TITLE
thermal: combine all thermal zones into a single test

### DIFF
--- a/boards/arrow,apq8096-db820c
+++ b/boards/arrow,apq8096-db820c
@@ -144,12 +144,16 @@ assert_device_present ufs-phy-phy1-probed ufs_qcom_phy_qmp_14nm 627000.*
 assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens 4a9000.*
 # 4 thermal zones: cpu x 4
+STATE=""
+RANGE=""
 for num in `seq 0 4`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 40000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
 
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 40000 "$RANGE"
 
 # PRNG
 assert_driver_present qcom-prng-driver-present msm_rng

--- a/boards/qcom,apq8016-sbc
+++ b/boards/qcom,apq8016-sbc
@@ -149,8 +149,13 @@ assert_device_present wcnss-rproc-device-probed qcom-wcnss-pil a204000.*
 assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens 4a9000.*
 # 4 thermal zones: cpu x 2, gpu, camera
+STATE=""
+RANGE=""
 for num in `seq 0 3`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 40000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
+
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 40000 "$RANGE"

--- a/boards/qcom,qcs404-evb
+++ b/boards/qcom,qcs404-evb
@@ -146,12 +146,16 @@ ensure_lib_firmware sdhci-msm-mount-lib-firmware
 assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens 4a9000.*
 # 10 thermal zones: cpu x 4, gpu, aoss, wlan, dsp, lpass, cpu cluster
+STATE=""
+RANGE=""
 for num in `seq 0 10`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 50000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
 
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 50000 "$RANGE"
 #for round in `seq 3`
 #do
 #	rproc-start wcnss-rproc-start-$round a204000.*

--- a/boards/qcom,qrb5165-rb5
+++ b/boards/qcom,qrb5165-rb5
@@ -100,11 +100,16 @@ assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens c263000.*
 assert_device_present thermal-device-tsens1-probed qcom-tsens c265000.*
 # 8 thermal zones: cpu x 8
+STATE=""
+RANGE=""
 for num in `seq 0 7`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 60000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
+
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 60000 "$RANGE"
 
 # PAS driver
 assert_driver_present qcom-pas-remoteproc-driver-present qcom_q6v5_pas

--- a/boards/qcom,sdm845-mtp
+++ b/boards/qcom,sdm845-mtp
@@ -174,11 +174,16 @@ assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens c263000.*
 assert_device_present thermal-device-tsens1-probed qcom-tsens c265000.*
 # 8 thermal zones: cpu x 8
+STATE=""
+RANGE=""
 for num in `seq 0 7`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 60000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
+
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 60000 "$RANGE"
 
 # PAS driver
 assert_driver_present qcom-pas-remoteproc-driver-present qcom_q6v5_pas

--- a/boards/thundercomm,db845c
+++ b/boards/thundercomm,db845c
@@ -182,11 +182,16 @@ assert_driver_present thermal-driver-tsens-present qcom-tsens
 assert_device_present thermal-device-tsens0-probed qcom-tsens c263000.*
 assert_device_present thermal-device-tsens1-probed qcom-tsens c265000.*
 # 8 thermal zones: cpu x 8
+STATE=""
+RANGE=""
 for num in `seq 0 7`
 do
-	state_check thermal-zone"${num}"-enabled /sys/class/thermal/thermal_zone"${num}"/mode enabled
-	value_in_range thermal-zone"${num}"-temperature /sys/class/thermal/thermal_zone"${num}"/temp 25000 60000
+    STATE="$STATE /sys/class/thermal/thermal_zone"${num}"/mode"
+    RANGE="$RANGE /sys/class/thermal/thermal_zone"${num}"/temp"
 done
+
+state_check thermal-zone-enabled enabled "$STATE"
+value_in_range thermal-zone-temperature 25000 60000 "$RANGE"
 
 # PAS driver
 assert_driver_present qcom-pas-remoteproc-driver-present qcom_q6v5_pas

--- a/helpers/state_check
+++ b/helpers/state_check
@@ -3,19 +3,24 @@
 . bootrr
 
 TEST_CASE_ID="$1"
-LOC="$2"
-STATE="$3"
+STATE="$2"
+shift 2
+# one or more files to check in batch mode
+LOC="$*"
 
 if [ -z "${TEST_CASE_ID}" -o -z "${LOC}" -o -z "${STATE}" ]; then
 	echo "Usage: $0 <test-case-id> <path> <desired state> [<timeout>]"
 	exit 1
 fi
 
-[ -r "${LOC}" ] || test_report_exit fail
+for f in ${LOC}; do
+	[ -r "${f}" ] || test_report_exit fail
 
-val=$(cat "$LOC")
-if [ "${val}" = "${STATE}" ]; then
-	test_report_exit pass
-else
-	test_report_exit fail
-fi
+	val=$(cat "$f")
+	if [ "${val}" != "${STATE}" ]; then
+		test_report_exit fail
+	fi
+done
+
+# if we are here, everything is all right!
+test_report_exit pass

--- a/helpers/value_in_range
+++ b/helpers/value_in_range
@@ -3,20 +3,26 @@
 . bootrr
 
 TEST_CASE_ID="$1"
-LOC="$2"
-LOW="$3"
-HIGH="$4"
+LOW="$2"
+HIGH="$3"
+shift 3
+# one or more files to check in batch mode
+LOC="$*"
 
 if [ -z "${TEST_CASE_ID}" -o -z "${LOC}" -o -z "${LOW}" -o -z "${HIGH}" ]; then
 	echo "Usage: $0 <test-case-id> <path> <low> <high> [<timeout>]"
 	exit 1
 fi
 
-[ -r "${LOC}" ] || test_report_exit fail
+for f in ${LOC}; do
 
-val=$(cat "${LOC}")
-if [ "${val}" -ge "${LOW}" -a "${val}" -le "${HIGH}" ]; then
-	test_report_exit pass
-else
-	test_report_exit fail
-fi
+	[ -r "${f}" ] || test_report_exit fail
+
+	val=$(cat "${f}")
+	if [ "${val}" -lt "${LOW}" -o "${val}" -gt "${HIGH}" ]; then
+		test_report_exit fail
+	fi
+done
+
+# if we are here, everything is all right!
+test_report_exit pass


### PR DESCRIPTION
Instead of reporting each thermal zone independently, test them all in
batch mode, and report one test case. When looking at the lists of
test results we will now have the same tests name for any platform
instead of a different number of tests executed for each of them.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>