### PR TITLE
boards/thundercomm,db845c: Add support for checking if cpufreq and cpuidle is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ HELPERS := assert_file_is_empty \
 	   assert_partition_found \
 	   assert_soundcard_present \
 	   assert_sysfs_attr_present \
+	   assert_cpufreq_enabled \
+	   assert_cpuidle_enabled \
 	   bootrr \
 	   bootrr-auto \
 	   ensure_lib_firmware \

--- a/boards/thundercomm,db845c
+++ b/boards/thundercomm,db845c
@@ -172,6 +172,10 @@ assert_device_present spmi-pmic-arb-device-probed spmi_pmic_arb c440000.*
 # CPUfreq
 assert_driver_present osm-driver-present qcom-cpufreq-hw
 assert_device_present osm-device-probed qcom-cpufreq-hw 17d43000.*
+assert_cpufreq_enabled cpufreq-cpu-enabled 7
+
+#CPUidle
+assert_cpuidle_enabled cpuidle-cpu-enabled 7
 
 # MPM
 

--- a/helpers/assert_cpufreq_enabled
+++ b/helpers/assert_cpufreq_enabled
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+NUM_CPUS="$2"
+
+if [ -z "${TEST_CASE_ID}" -o -z "${NUM_CPUS}" ]; then
+	echo "Usage: $0 <test-case-id> <#cpus>"
+	exit 1
+fi
+
+CPU=0
+
+while [  $CPU -le $NUM_CPUS ]; do
+	[ -f /sys/devices/system/cpu/cpu${CPU}/cpufreq/scaling_driver ] || test_report_exit fail
+	let CPU=CPU+1
+done
+test_report_exit pass

--- a/helpers/assert_cpuidle_enabled
+++ b/helpers/assert_cpuidle_enabled
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+. bootrr
+
+TEST_CASE_ID="$1"
+NUM_CPUS="$2"
+
+if [ -z "${TEST_CASE_ID}" -o -z "${NUM_CPUS}" ]; then
+	echo "Usage: $0 <test-case-id> <#cpus>"
+	exit 1
+fi
+
+CPU=0
+
+while [  $CPU -le $NUM_CPUS ]; do
+	[ -d /sys/devices/system/cpu/cpu${CPU}/cpuidle ] || test_report_exit fail
+	let CPU=CPU+1
+done
+test_report_exit pass


### PR DESCRIPTION

Add helper files to check if cpufreq and cpuidle are enabled. Also
add the test support for db845c.

Signed-off-by: Thara Gopinath <thara.gopinath@linaro.org>