### PR TITLE
boards: Add Qualcomm sa8155p ADP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ BOARDS := arrow,apq8096-db820c \
 	  qcom,msm8998-mtp \
 	  qcom,sdm845-mtp \
 	  qcom,sm8150-mtp \
+	  qcom,sa8155p-adp \
 	  qcom,sm8250-mtp \
 	  qcom,sm8350-mtp \
 	  qcom,qrb5165-rb5 \

--- a/boards/qcom,sa8155p-adp
+++ b/boards/qcom,sa8155p-adp
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+#RPMH
+assert_driver_present cmd-db-driver-present cmd-db
+assert_driver_present rpmh-driver-present rpmh
+assert_driver_present rpmh-clock-driver-present clk-rpmh
+assert_driver_present rpmh-regulator-driver-present qcom-rpmh-regulator
+#assert_driver_present rpmh-pd-driver-present qcom-rpmhpd
+
+assert_device_present cmd-db-device-probed cmd-db 85f20000.*
+assert_device_present rpmh-device-probed rpmh 18200000.*
+assert_device_present rpmh-clock-device-probed clk-rpmh 18200000.*
+assert_device_present rpmh-pm8009-regulator-device-probed qcom-rpmh-regulator *pm8009*
+assert_device_present rpmh-pm8150-regulator-device-probed qcom-rpmh-regulator *pm8150-*
+assert_device_present rpmh-pm8150l-regulator-device-probed qcom-rpmh-regulator *pm8150l-*
+
+# AOSS
+
+# PDC
+
+# APCS
+assert_driver_present apcs-ipc-driver-present qcom_apcs_ipc
+assert_device_present apcs-ipc-device-probed qcom_apcs_ipc 17c00000.*
+
+# GCC
+assert_driver_present gcc-driver-present gcc-sm8150
+assert_device_present gcc-device-probed gcc-sm8150 100000.*
+
+# GENI
+
+# I2C GENI
+
+# QFPROM
+
+# SCM
+assert_driver_present scm-driver-present qcom_scm
+assert_device_present scm-device-probed qcom_scm firmware:scm
+
+# Serial
+assert_driver_present geni-uart-driver-present qcom_geni_serial
+assert_device_present geni-uart-uart9-probed qcom_geni_serial a90000.*
+
+# SMEM
+assert_driver_present smem-driver-present qcom-smem
+assert_device_present smem-device-probed qcom-smem smem
+assert_driver_present smem-socinfo-driver-present qcom-socinfo
+
+# SMMU
+
+# TCSR mutex
+assert_driver_present tcsr-mutex-driver-present qcom_hwspinlock
+assert_device_present tcsr-mutex-device-probed qcom_hwspinlock hwlock
+
+# Timer
+
+# TLMM
+assert_driver_present tlmm-driver-present sm8150-pinctrl
+assert_device_present tlmm-device-probed sm8150-pinctrl 3100000.*
+
+# GLINK/SMEM
+
+# GLINK/SPSS
+
+# IPCROUTER
+
+# SMP2P
+assert_driver_present smp2p-driver-present qcom_smp2p
+assert_device_present smp2p-slpi-device-probed qcom_smp2p *cdsp*
+assert_device_present smp2p-adsp-device-probed qcom_smp2p *lpass*
+assert_device_present smp2p-modem-device-probed qcom_smp2p *mpss*
+assert_device_present smp2p-slpi-device-probed qcom_smp2p *slpi*
+
+# SPCOM
+
+# CCI
+
+# CPP
+
+# CSID
+
+# CSIPHY
+
+# Face Detect
+
+# JPEG
+
+# VFE
+
+# FastRPC
+
+# QCrypto
+
+# PRNG
+
+# Coresight
+
+# Watchdog
+
+# PCIe
+
+# QMP phy
+
+# PMIC
+## Charger
+
+## clkdiv
+
+## Coincell
+
+## Fuel guage
+
+## GPIO
+
+## Haptics
+
+## LABIBB
+
+## LPG
+
+## PON
+
+## QNovo
+
+## Regulators
+
+## RTC
+
+# SPMI
+assert_driver_present spmi-pmic-arb-driver-present spmi_pmic_arb
+assert_device_present spmi-pmic-arb-device-probed spmi_pmic_arb c440000.*
+
+## temp-alarm
+
+## VADC
+
+## WLED
+
+# CPUfreq
+
+# MPM
+
+# SPM
+
+# Tsens
+
+# PAS driver
+
+# Modem PIL
+
+# rmtfs memory
+
+# Secure PIL
+
+# Sensor PIL
+
+# UFS QMP
+assert_driver_present ufs-phy-driver-present qcom-qmp-phy
+assert_device_present ufs-phy-probed qcom-qmp-phy 1d87000.*
+
+# UFSHCD
+assert_driver_present ufs-hcd-driver-present ufshcd-qcom
+assert_device_present ufs-hcd-device-probed ufshcd-qcom 1d84000.*


### PR DESCRIPTION
Add the bootrr board file for sa8155p adp board.
Keep similar test entries as present on sm8150-mtp board for now.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>