### PR TITLE
Makefile: Override owner of files in cpio archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install: $(all-install)
 CPIO := $(PWD)/$(CPIONAME).cpio
 
 $(CPIO): $(all-install)
-	@cd $(DESTDIR) && find ./$(prefix) | cpio -o -H newc > $(CPIO)
+	@cd $(DESTDIR) && find ./$(prefix) | cpio -o -H newc -R +0:+0 > $(CPIO)
 
 %.cpio.gz: %.cpio
 	@gzip < $< > $@


### PR DESCRIPTION
In the typical scenario where the bootrr cpio archive is concatenated onto some ramdisk, attributes of this cpio archive will overwrite those previously extracted.

When used in combination with a ramdisk with systemd, this results in many services failing to start, because the namespaced services does not have permission to open e.g. /

Fix this my overriding the owner and group.