### PR TITLE
helpers/bootrr: Silence the lava-test-case test

### DIFF
--- a/helpers/bootrr
+++ b/helpers/bootrr
@@ -2,7 +2,7 @@
 
 test_report_exit() {
 	TEST_RESULT=$1
-	command -v lava-test-case
+	command -v lava-test-case > /dev/null
 	if [ "$?" -eq 0 ]; then
 		lava-test-case "${TEST_CASE_ID}" --result ${TEST_RESULT}
 	else


### PR DESCRIPTION
`command -v` is invoked to check if lava-test-case exists, to know if we need to fake it using `echo`. But in the event that lava-test-case actually exist it also prints the full path of the executable.

Pipe the output to /dev/null, as we only care about the exit code.