### PR TITLE
github: Introduce workflow for generating bootrr.cpio

### DIFF
--- a/.github/workflows/generate-cpio-archive.yml
+++ b/.github/workflows/generate-cpio-archive.yml
@@ -1,0 +1,19 @@
+name: generate-cpio-archive
+on:
+  push:
+    branches: master
+
+jobs:
+  generate-cpio:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout master
+        uses: actions/checkout@v4
+      - name: make cpio.gz
+        run: |
+          make cpio.gz
+      - name: archive bootrr.cpio.gz
+        uses: actions/upload-artifact@v4
+        with:
+          name: bootrr.cpio.gz
+          path: bootrr.cpio.gz


### PR DESCRIPTION
For kernel CI purposes it's convenient to always have access to the latest bootrr.cpio archive. Introduce a workflow that composes this and generates an artifact.